### PR TITLE
Change register_alias to register_alias_force

### DIFF
--- a/straw.lua
+++ b/straw.lua
@@ -1,9 +1,9 @@
-minetest.register_alias("cottages:straw",      "farming:straw")
-minetest.register_alias("castle:straw",        "farming:straw")
-minetest.register_alias("darkage:straw",       "farming:straw")
-minetest.register_alias("cottages:straw_bale", "castle_farming:bound_straw")
-minetest.register_alias("darkage:straw_bale",  "castle_farming:bound_straw")
-minetest.register_alias("castle:bound_straw",  "castle_farming:bound_straw")
+minetest.register_alias_force("cottages:straw",      "farming:straw")
+minetest.register_alias_force("castle:straw",        "farming:straw")
+minetest.register_alias_force("darkage:straw",       "farming:straw")
+minetest.register_alias_force("cottages:straw_bale", "castle_farming:bound_straw")
+minetest.register_alias_force("darkage:straw_bale",  "castle_farming:bound_straw")
+minetest.register_alias_force("castle:bound_straw",  "castle_farming:bound_straw")
 
 -- internationalization boilerplate
 local MP = minetest.get_modpath(minetest.get_current_modname())


### PR DESCRIPTION
Avoids having three different nodes of straw when having castle, darkage and cottages installed